### PR TITLE
feat: compare the fields of backend model and it's corresponding type file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,8 @@ checks = [
 ]
 
 exclude = [
-    "^.*\\.Meta$",    # Meta classes
-    "^.*\\.__str__$", # __str__ methods
-    "^__init__$",     # __init__ files
+    "^.*\\.Meta$",     # Meta classes
+    "^.*\\.__str__$",  # __str__ methods
+    "^__init__$",      # __init__ files
+    "^.*\\.__init__$", # __init__ methods
 ]

--- a/src/tsbe_check/__init__.py
+++ b/src/tsbe_check/__init__.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 __version__ = "1.0.0"
 
+from .checker import TypeChecker
 from .cli import cli
 
-__all__ = ["cli"]
+__all__ = ["cli", "TypeChecker"]

--- a/src/tsbe_check/checker.py
+++ b/src/tsbe_check/checker.py
@@ -1,0 +1,185 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""
+Main module for checking Django models against TypeScript types.
+"""
+
+from typing import Dict, List, Set
+
+from .django_parser import extract_model_fields
+from .typescript_parser import TypeScriptParser
+from .utils import snake_to_camel
+
+
+class TypeChecker:
+    """
+    Main class for checking Django models against TypeScript types.
+
+    Parameters
+    ----------
+    models_file : str
+        The file path for the models file to check.
+
+    types_file : str
+        The file path for the TypeScript file to check.
+    """
+
+    def __init__(self, models_file: str, types_file: str) -> None:
+        self.models_file = models_file
+        self.types_file = types_file
+        self.model_fields = extract_model_fields(models_file)
+        self.ts_parser = TypeScriptParser(types_file)
+        self.ts_interfaces = self.ts_parser.parse_interfaces()
+        self.backend_only = self.ts_parser.get_backend_only_fields()
+
+    def check(self) -> List[str]:
+        """
+        Check models against TypeScript types.
+
+        Returns
+        -------
+        list
+            A list of fields missing from the TypeScript file.
+        """
+        missing_fields = []
+
+        for model_name, fields in self.model_fields.items():
+            interfaces = self._find_matching_interfaces(model_name)
+
+            if not interfaces:
+                missing_fields.append(
+                    self._format_missing_interface_message(model_name)
+                )
+                continue
+
+            missing_fields.extend(
+                self._format_missing_field_message(field, model_name, interfaces)
+                for field in fields
+                if not self._is_field_accounted_for(field, interfaces)
+            )
+
+        return missing_fields
+
+    def _find_matching_interfaces(self, model_name: str) -> Dict[str, Set[str]]:
+        """
+        Find matching TypeScript interfaces for a model.
+
+        Parameters
+        ----------
+        model_name : str
+            The name of the model to check the frontend TypeScript file for.
+
+        Returns
+        -------
+        Dict[str, Set[str]]
+            Interfaces that match a model name.
+        """
+        potential_names = self._generate_potential_names(model_name)
+        return {
+            name: interface.fields
+            for name, interface in self.ts_interfaces.items()
+            if any(potential == name for potential in potential_names)
+        }
+
+    @staticmethod
+    def _generate_potential_names(model_name: str) -> List[str]:
+        """
+        Generate potential TypeScript interface names for a model.
+
+        Parameters
+        ----------
+        model_name : str
+            The name of the model to check the frontend TypeScript file for.
+
+        Returns
+        -------
+        List[str]
+            Possible names for the model to check for.
+        """
+        base_names = [
+            model_name,
+            model_name.replace("Model", ""),
+        ]
+
+        if "_" in model_name:
+            base_names.append(snake_to_camel(input_str=model_name))
+
+        suffixes = ["", "Base", "Response", "Type"]
+        return [f"{base}{suffix}" for base in base_names for suffix in suffixes]
+
+    def _is_field_accounted_for(
+        self, field: str, interfaces: Dict[str, Set[str]]
+    ) -> bool:
+        """
+        Check if a field is accounted for in TypeScript.
+
+        Parameters
+        ----------
+        field : str
+            The field that should be used in the frontend TypeScript file.
+
+        interfaces : Dict[str, Set[str]]
+            The interfaces from the frontend TypeScript file.
+
+        Returns
+        -------
+        Bool
+            Whether the field is accounted for in the frontend TypeScript file.
+        """
+        camel_field = snake_to_camel(input_str=field)
+        return (
+            camel_field in self.backend_only
+            or field in self.backend_only
+            or any(camel_field in fields for fields in interfaces.values())
+        )
+
+    @staticmethod
+    def _format_missing_interface_message(model_name: str) -> str:
+        """
+        Format message for missing interface.
+
+        Parameters
+        ----------
+        model_name : str
+            The name of the model that an interface is missing from.
+
+        Returns
+        -------
+        str
+            The message displayed to the user when missing interfaces are found.
+        """
+        potential_names = TypeChecker._generate_potential_names(model_name)
+        return (
+            f"\nNo matching TypeScript interface found for model: {model_name}\n"
+            f"Searched for interfaces: {', '.join(potential_names)}"
+        )
+
+    @staticmethod
+    def _format_missing_field_message(
+        field: str, model_name: str, interfaces: Dict[str, Set[str]]
+    ) -> str:
+        """
+        Format message for missing field.
+
+        Parameters
+        ----------
+        field : str
+            The model field that's missing.
+
+        model_name : str
+            The name of the model that the field is missing from.
+
+        interfaces : Dict[str, Set[str]]
+            The interfaces that have been searched.
+
+        Returns
+        -------
+        str
+            The message displayed to the user when missing fields are found.
+        """
+        camel_field = snake_to_camel(input_str=field)
+        return (
+            f"\nField '{field}' (camelCase: '{camel_field}') from model '{model_name}' "
+            f"is missing in TypeScript types.\n"
+            f"Expected to find in interface(s): {', '.join(interfaces.keys())}\n"
+            f"To ignore this field, add a comment that references it like: '// Note: {camel_field} is backend only'"
+        ) 

--- a/src/tsbe_check/checker.py
+++ b/src/tsbe_check/checker.py
@@ -182,4 +182,4 @@ class TypeChecker:
             f"is missing in TypeScript types.\n"
             f"Expected to find in interface(s): {', '.join(interfaces.keys())}\n"
             f"To ignore this field, add a comment that references it like: '// Note: {camel_field} is backend only'"
-        ) 
+        )

--- a/src/tsbe_check/cli/main.py
+++ b/src/tsbe_check/cli/main.py
@@ -18,9 +18,9 @@ def cli():
 
 
 @cli.command()
-@click.argument("typescript_file", type=click.Path(exists=True))
 @click.argument("backend_model", type=click.Path(exists=True))
-def check(typescript_file: str, backend_model: str):
+@click.argument("typescript_file", type=click.Path(exists=True))
+def check(backend_model: str, typescript_file: str):
     """Check TypeScript types against backend models.
 
     This command checks if all fields from the backend model are properly represented
@@ -28,9 +28,9 @@ def check(typescript_file: str, backend_model: str):
     special comments in the TypeScript file.
 
     Example usage:
-    tsbe-check check src/types/user.ts src/models/user.py
+    tsbe-check check src/models/user.py src/types/user.ts
     """
-    checker = TypeChecker(backend_model, typescript_file)
+    checker = TypeChecker(models_file=backend_model, types_file=typescript_file)
     if missing := checker.check():
         click.echo("Missing TypeScript fields found:")
         click.echo("\n".join(missing))

--- a/src/tsbe_check/cli/main.py
+++ b/src/tsbe_check/cli/main.py
@@ -13,7 +13,9 @@ from ..checker import TypeChecker
 @click.group()
 @click.version_option()
 def cli():
-    """tsbe-check is a Python package used to check TypeScript types against their corresponding backend models."""
+    """
+    TS Backend Check is a Python package used to check TypeScript types against their corresponding backend models.
+    """
     pass
 
 
@@ -21,13 +23,23 @@ def cli():
 @click.argument("backend_model", type=click.Path(exists=True))
 @click.argument("typescript_file", type=click.Path(exists=True))
 def check(backend_model: str, typescript_file: str):
-    """Check TypeScript types against backend models.
+    """
+    Check TypeScript types against backend models.
 
     This command checks if all fields from the backend model are properly represented
     in the TypeScript types file. It supports marking fields as backend-only using
     special comments in the TypeScript file.
 
-    Example usage:
+    Parameters
+    ----------
+    backend_model : str
+        The path to the backend model file (e.g. Python class).
+
+    typescript_file : str
+        The path to the TypeScript interface/type file.
+
+    Examples
+    --------
     tsbe-check check src/models/user.py src/types/user.ts
     """
     checker = TypeChecker(models_file=backend_model, types_file=typescript_file)

--- a/src/tsbe_check/cli/main.py
+++ b/src/tsbe_check/cli/main.py
@@ -3,7 +3,11 @@
 Setup and commands for the tsbe-check command line interface.
 """
 
+import sys
+
 import click
+
+from ..checker import TypeChecker
 
 
 @click.group()
@@ -17,7 +21,25 @@ def cli():
 @click.argument("typescript_file", type=click.Path(exists=True))
 @click.argument("backend_model", type=click.Path(exists=True))
 def check(typescript_file: str, backend_model: str):
-    click.echo(f"Checking {typescript_file} against {backend_model}")
+    """Check TypeScript types against backend models.
+
+    This command checks if all fields from the backend model are properly represented
+    in the TypeScript types file. It supports marking fields as backend-only using
+    special comments in the TypeScript file.
+
+    Example usage:
+    tsbe-check check src/types/user.ts src/models/user.py
+    """
+    checker = TypeChecker(backend_model, typescript_file)
+    if missing := checker.check():
+        click.echo("Missing TypeScript fields found:")
+        click.echo("\n".join(missing))
+        click.echo(
+            f"\nPlease correct the {len(missing)} fields above to have backend models and frontend types fully synced."
+        )
+        sys.exit(1)
+
+    click.echo("All model fields are properly typed in TypeScript!")
 
 
 if __name__ == "__main__":

--- a/src/tsbe_check/django_parser.py
+++ b/src/tsbe_check/django_parser.py
@@ -1,0 +1,103 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""
+Module for parsing Django models and extracting field information.
+"""
+
+import ast
+from typing import Dict, Set
+
+
+class DjangoModelVisitor(ast.NodeVisitor):
+    """
+    AST visitor to extract fields from Django models.
+    """
+
+    DJANGO_FIELD_TYPES = {
+        "Field",
+        "CharField",
+        "TextField",
+        "IntegerField",
+        "BooleanField",
+        "DateTimeField",
+        "ForeignKey",
+        "ManyToManyField",
+        "OneToOneField",
+        "EmailField",
+        "URLField",
+        "FileField",
+        "ImageField",
+        "DecimalField",
+        "AutoField",
+    }
+
+    def __init__(self) -> None:
+        self.models: Dict[str, Set[str]] = {}
+        self.current_model: str | None = None
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        """
+        Check class definitions, specifically those that inherit from other classes.
+
+        Parameters
+        ----------
+        node : ast.ClassDef
+            A class definition from Python AST (Abstract Syntax Tree).
+            It contains information about the class, such as its name, base classes, body, decorators, etc.
+        """
+        # Only process classes that inherit from something.
+        if node.bases:
+            self.current_model = node.name
+            if self.current_model not in self.models:
+                self.models[self.current_model] = set()
+
+            self.generic_visit(node)
+
+        self.current_model = None
+
+    def visit_Assign(self, node: ast.Assign) -> None:
+        """
+        Check assignment statements within a class.
+
+        Parameters
+        ----------
+        node : ast.Assign
+            An assignment definition from Python AST (Abstract Syntax Tree).
+            It represents an assignment statement (e.g., x = 42).
+        """
+        if not self.current_model:
+            return
+
+        for target in node.targets:
+            if (
+                isinstance(target, ast.Name)
+                and not target.id.startswith("_")
+                and isinstance(node.value, ast.Call)
+                and hasattr(node.value.func, "attr")
+            ) and any(
+                field_type in node.value.func.attr
+                for field_type in self.DJANGO_FIELD_TYPES
+            ):
+                self.models[self.current_model].add(target.id)
+
+
+def extract_model_fields(models_file: str) -> Dict[str, Set[str]]:
+    """
+    Extract fields from Django models file.
+
+    Parameters
+    ----------
+    models_file : str
+        A models.py file that defines Django models.
+
+    Returns
+    -------
+    Dict[str, Set[str]]
+        The fields from the models file extracted into a dictionary for future processing.
+    """
+    with open(models_file, "r", encoding="utf-8") as f:
+        tree = ast.parse(f.read())
+
+    visitor = DjangoModelVisitor()
+    visitor.visit(tree)
+
+    return visitor.models 

--- a/src/tsbe_check/django_parser.py
+++ b/src/tsbe_check/django_parser.py
@@ -95,7 +95,17 @@ def extract_model_fields(models_file: str) -> Dict[str, Set[str]]:
         The fields from the models file extracted into a dictionary for future processing.
     """
     with open(models_file, "r", encoding="utf-8") as f:
-        tree = ast.parse(f.read())
+        content = f.read().strip() 
+        # Skip any empty lines at the beginning
+        while content.startswith("\n"):
+            content = content[1:]
+
+    try:
+        tree = ast.parse(content)
+    except SyntaxError as e:
+        raise SyntaxError(
+            f"Failed to parse {models_file}. Make sure it's a valid Python file. Error: {str(e)}"
+        ) from e
 
     visitor = DjangoModelVisitor()
     visitor.visit(tree)

--- a/src/tsbe_check/django_parser.py
+++ b/src/tsbe_check/django_parser.py
@@ -95,7 +95,7 @@ def extract_model_fields(models_file: str) -> Dict[str, Set[str]]:
         The fields from the models file extracted into a dictionary for future processing.
     """
     with open(models_file, "r", encoding="utf-8") as f:
-        content = f.read().strip() 
+        content = f.read().strip()
         # Skip any empty lines at the beginning
         while content.startswith("\n"):
             content = content[1:]
@@ -110,4 +110,4 @@ def extract_model_fields(models_file: str) -> Dict[str, Set[str]]:
     visitor = DjangoModelVisitor()
     visitor.visit(tree)
 
-    return visitor.models 
+    return visitor.models

--- a/src/tsbe_check/typescript_parser.py
+++ b/src/tsbe_check/typescript_parser.py
@@ -102,4 +102,4 @@ class TypeScriptParser:
         # Readonly fields
         fields.update(re.findall(r"readonly\s+(\w+)\s*[?]?\s*:", interface_body))
 
-        return fields 
+        return fields

--- a/src/tsbe_check/typescript_parser.py
+++ b/src/tsbe_check/typescript_parser.py
@@ -1,0 +1,105 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""
+Module for parsing TypeScript interfaces and types.
+"""
+
+import re
+from dataclasses import dataclass
+from typing import Dict, List, Set
+
+
+@dataclass
+class TypeScriptInterface:
+    """
+    Represents a TypeScript interface with its fields and parent interfaces.
+    """
+
+    name: str
+    fields: Set[str]
+    parents: List[str]
+
+
+class TypeScriptParser:
+    """
+    Parser for TypeScript interface files.
+
+    Parameters
+    ----------
+    file_path : str
+        The file path for the TypeScript file to parse.
+    """
+
+    def __init__(self, file_path: str) -> None:
+        self.file_path = file_path
+        with open(file_path, "r", encoding="utf-8") as f:
+            self.content = f.read()
+
+    def parse_interfaces(self) -> Dict[str, TypeScriptInterface]:
+        """
+        Parse TypeScript interfaces from the file.
+
+        Returns
+        -------
+        Dict[str, TypeScriptInterface]
+            The interface parsed into a dictionary for future processing.
+        """
+        interfaces = {}
+        interface_pattern = (
+            r"(?:export\s+|declare\s+)?interface\s+(\w+)"
+            r"(?:\s+extends\s+([^{]+))?\s*{([\s\S]*?)}"
+        )
+
+        for match in re.finditer(interface_pattern, self.content):
+            name = match.group(1)
+            parents = (
+                [p.strip() for p in match.group(2).split(",")] if match.group(2) else []
+            )
+            fields = self._extract_fields(match.group(3))
+
+            interfaces[name] = TypeScriptInterface(name, fields, parents)
+
+        return interfaces
+
+    def get_backend_only_fields(self) -> Set[str]:
+        """
+        Extract fields marked as backend-only in comments.
+
+        Returns
+        -------
+        Set[str]
+            The field names that are marked with a backend-only identifier to ignore them.
+        """
+        patterns = [
+            r"//.*?Note:\s*(\w+)\s+is\s+backend\s+only",
+            r"//.*?(\w+)\s+is\s+backend\s+only",
+            r"//\s*@backend-only\s+(\w+)",
+            r"//.*?backend-only:\s*(\w+)",
+        ]
+        return {
+            match for pattern in patterns for match in re.findall(pattern, self.content)
+        }
+
+    @staticmethod
+    def _extract_fields(interface_body: str) -> Set[str]:
+        """
+        Extract field names from interface body.
+
+        Parameters
+        ----------
+        interface_body : str
+            A string representation of the interface body of the model.
+
+        Returns
+        -------
+        Set[str]
+            The field names from the model interface body.
+        """
+        fields = set()
+
+        # Regular fields
+        fields.update(re.findall(r"(?://[^\n]*\n)*\s*(\w+)\s*[?]?\s*:", interface_body))
+
+        # Readonly fields
+        fields.update(re.findall(r"readonly\s+(\w+)\s*[?]?\s*:", interface_body))
+
+        return fields 

--- a/src/tsbe_check/utils.py
+++ b/src/tsbe_check/utils.py
@@ -3,8 +3,6 @@
 Utility functions for tsbe-check.
 """
 
-import re
-
 
 def snake_to_camel(input_str: str) -> str:
     """

--- a/src/tsbe_check/utils.py
+++ b/src/tsbe_check/utils.py
@@ -2,3 +2,23 @@
 """
 Utility functions for tsbe-check.
 """
+
+import re
+
+
+def snake_to_camel(input_str: str) -> str:
+    """
+    Convert snake_case to camelCase.
+
+    Parameters
+    ----------
+    input_str : str
+        The snake_case string to convert.
+
+    Returns
+    -------
+    str
+        The camelCase version of the input string.
+    """
+    components = input_str.split("_")
+    return components[0] + "".join(x.title() for x in components[1:])


### PR DESCRIPTION
the cli tool here allow us to compare the backend model fields and it's corresponding type file fields, and report all the fields that are missing in the corresponding type file.

```ts
tsbe-check check activist\backend\events\models.py activist\frontend\types\events\event.d.ts
``` 
you can ignore the field my adding comment, for example below in `event.d.ts` file I am ignoring `isPrivate` field by adding  
`// Note: isPrivate is backend only`
![isPrivate](https://github.com/user-attachments/assets/f604bf09-22a2-4f79-821d-6388e7050ffd)


result
```ts
Missing TypeScript fields found:

Field 'tasks' (camelCase: 'tasks') from model 'Event' is missing in TypeScript types.
Expected to find in interface(s): EventBase, Event, EventResponse
To ignore this field, add a comment that references it like: '// Note: tasks is backend only'

Field 'faqs' (camelCase: 'faqs') from model 'Event' is missing in TypeScript types.
Expected to find in interface(s): EventBase, Event, EventResponse
To ignore this field, add a comment that references it like: '// Note: faqs is backend only'

Field 'roles' (camelCase: 'roles') from model 'Event' is missing in TypeScript types.
Expected to find in interface(s): EventBase, Event, EventResponse
To ignore this field, add a comment that references it like: '// Note: roles is backend only'

Field 'topics' (camelCase: 'topics') from model 'Event' is missing in TypeScript types.
Expected to find in interface(s): EventBase, Event, EventResponse
To ignore this field, add a comment that references it like: '// Note: topics is backend only'

Field 'deletion_date' (camelCase: 'deletionDate') from model 'Event' is missing in TypeScript types.
Expected to find in interface(s): EventBase, Event, EventResponse
To ignore this field, add a comment that references it like: '// Note: deletionDate is backend only'

Field 'tags' (camelCase: 'tags') from model 'Event' is missing in TypeScript types.
Expected to find in interface(s): EventBase, Event, EventResponse
To ignore this field, add a comment that references it like: '// Note: tags is backend only'

Field 'dicussions' (camelCase: 'dicussions') from model 'Event' is missing in TypeScript types.
Expected to find in interface(s): EventBase, Event, EventResponse
To ignore this field, add a comment that references it like: '// Note: dicussions is backend only'

Field 'formats' (camelCase: 'formats') from model 'Event' is missing in TypeScript types.
Expected to find in interface(s): EventBase, Event, EventResponse
To ignore this field, add a comment that references it like: '// Note: formats is backend only'

No matching TypeScript interface found for model: Format
Searched for interfaces: Format, FormatBase, FormatResponse, FormatType, Format, FormatBase, FormatResponse, FormatType

No matching TypeScript interface found for model: Role
Searched for interfaces: Role, RoleBase, RoleResponse, RoleType, Role, RoleBase, RoleResponse, RoleType      

Field 'event' (camelCase: 'event') from model 'EventAttendee' is missing in TypeScript types.
Expected to find in interface(s): EventAttendee
To ignore this field, add a comment that references it like: '// Note: event is backend only'

Field 'role' (camelCase: 'role') from model 'EventAttendee' is missing in TypeScript types.
Expected to find in interface(s): EventAttendee
To ignore this field, add a comment that references it like: '// Note: role is backend only'

Field 'user' (camelCase: 'user') from model 'EventAttendee' is missing in TypeScript types.
Expected to find in interface(s): EventAttendee
To ignore this field, add a comment that references it like: '// Note: user is backend only'

No matching TypeScript interface found for model: EventAttendeeStatus
Searched for interfaces: EventAttendeeStatus, EventAttendeeStatusBase, EventAttendeeStatusResponse, EventAttendeeStatusType, EventAttendeeStatus, EventAttendeeStatusBase, EventAttendeeStatusResponse, EventAttendeeStatusType

Field 'event' (camelCase: 'event') from model 'EventSocialLink' is missing in TypeScript types.
Expected to find in interface(s): EventSocialLink
To ignore this field, add a comment that references it like: '// Note: event is backend only'

Field 'event' (camelCase: 'event') from model 'EventText' is missing in TypeScript types.
Expected to find in interface(s): EventText
To ignore this field, add a comment that references it like: '// Note: event is backend only'

Please correct the 16 fields above to have backend models and frontend types fully synced.
```

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #ISSUE_NUMBER
